### PR TITLE
patch for confignetwork redhat8

### DIFF
--- a/xCAT/postscripts/confignetwork
+++ b/xCAT/postscripts/confignetwork
@@ -696,7 +696,7 @@ if [ -n "$valid_sorted_nicdevice_list" ]; then
     echo "$valid_sorted_nicdevice_list" |log_lines info
 fi
 #enable network service
-enable_network_service
+#enable_network_service
 
 #config nics and ifcfg files
 configure_nicdevice "$valid_sorted_nicdevice_list"


### PR DESCRIPTION
### The PR is to fix issue https://github.com/xcat2/xcat2-task-management/issues/399

###changes:
delete "stop NetworkManager" function, let develop autotest env to run it first.



